### PR TITLE
Task/set fixed dc version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.9
+      - image: circleci/python:3.7.4
 
     working_directory: ~/repo
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('HISTORY.md') as history_file:
 
 setuptools.setup(
     name='datacatalog-tag-template-exporter',
-    version='0.1.1',
+    version='0.1.2',
     author='Marcelo Miranda',
     author_email='mesmacosta@gmail.com',
     description='A package to manage Google Cloud Data Catalog'
@@ -23,7 +23,7 @@ setuptools.setup(
     },
     include_package_data=True,
     install_requires=(
-        'google-cloud-datacatalog',
+        'google-cloud-datacatalog>=1,<2',
         'pandas',
     ),
     setup_requires=('pytest-runner', ),


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Set fixed versions on setup.py to avoid breaking changes for new versions of Data Catalog library.

**- How I did it**
--

**- How to verify it**
Install from PyPI and run datacatalog-util

**- Description for the changelog**
Set fixed versions on setup.py to avoid breaking changes for new versions of Data Catalog library.
